### PR TITLE
fix: apply naming rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Report a bug
-description: Tell us about a bug or issue you may have identified in UDS Android.
+description: Tell us about a bug or issue you may have identified in OUDS Android.
 title: "[Bug]: Bug Summary"
 labels: ["🐞 bug", "🔍 triage"]
 assignees: ["florentmaitre", "paulinea"]
@@ -9,7 +9,7 @@ body:
       label: Prerequisites
       description: Take a couple minutes to help our maintainers work faster.
       options:
-        - label: I have [searched the backlog](https://github.com/uds-sandbox/uds-android/issues) for duplicate or closed feature requests
+        - label: I have [searched the backlog](https://github.com/ouds-sandbox/ouds-android/issues) for duplicate or closed feature requests
           required: true
   - type: input
     id: device

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
       label: Prerequisites
       description: Take a couple minutes to help our maintainers work faster.
       options:
-        - label: I have [searched the backlog](https://github.com/uds-sandbox/uds-android/issues) for duplicate or closed feature requests
+        - label: I have [searched the backlog](https://github.com/ouds-sandbox/ouds-android/issues) for duplicate or closed feature requests
           required: true
   - type: markdown
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ Following these guidelines helps to communicate that you respect the time of the
 
 ## Using the Issue Tracker
 
-The [issue tracker](https://github.com/uds-sandbox/uds-android/issues) is the preferred channel for [bug reports](#bug-reports), [feature requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
+The [issue tracker](https://github.com/ouds-sandbox/ouds-android/issues) is the preferred channel for [bug reports](#bug-reports), [feature requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
 
-- Please **do not** use the issue tracker for personal support requests. [GitHub Discussions](https://github.com/uds-sandbox/uds-android/discussions/categories/q-a) or our internal Orange communication tools are better places to get help.
+- Please **do not** use the issue tracker for personal support requests. [GitHub Discussions](https://github.com/ouds-sandbox/ouds-android/discussions/categories/q-a) or our internal Orange communication tools are better places to get help.
 
 - Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 
@@ -23,7 +23,7 @@ Our bug tracker utilizes several labels to help organize and identify issues. He
 - `feature` - Issues asking for a new feature to be added, or an existing one to be extended or modified. New features require a minor version bump (e.g., `v1.0.0` to `v1.1.0`).
 - `help wanted` - Issues we need or would love help from the community to resolve.
 
-For a complete look at our labels, see the [project labels page](https://github.com/uds-sandbox/uds-android/labels).
+For a complete look at our labels, see the [project labels page](https://github.com/ouds-sandbox/ouds-android/labels).
 
 ## Bug Reports
 
@@ -75,11 +75,11 @@ Adhering to the following process is the best way to get your work included in t
 
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone https://github.com/<your-username>/uds-android.git
+   git clone https://github.com/<your-username>/ouds-android.git
    # Navigate to the newly cloned directory
-   cd uds-android
+   cd ouds-android
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/uds-sandbox/uds-android.git
+   git remote add upstream https://github.com/ouds-sandbox/ouds-android.git
    ```
 
 2. If you cloned a while ago, get the latest changes from upstream:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   OUDS Android provides Orange Android components to developers and a demo application.
   <br>
   <br>
-  <a href="https://github.com/uds-sandbox/uds-android/issues/new?assignees=paulinea&labels=%F0%9F%90%9E+bug%2C%F0%9F%94%8D+triage&template=bug_report.yml&title=[Bug]%3A+Bug+Summary">Report bug</a>
+  <a href="https://github.com/ouds-sandbox/ouds-android/issues/new?assignees=paulinea&labels=%F0%9F%90%9E+bug%2C%F0%9F%94%8D+triage&template=bug_report.yml&title=[Bug]%3A+Bug+Summary">Report bug</a>
   ·
-  <a href="https://github.com/uds-sandbox/uds-android/issues/new?assignees=paulinea&labels=feature%2C%F0%9F%94%8D%20triage&template=feature_request.yml&title=[feature]%3A+">Request feature</a>
+  <a href="https://github.com/ouds-sandbox/ouds-android/issues/new?assignees=paulinea&labels=feature%2C%F0%9F%94%8D%20triage&template=feature_request.yml&title=[feature]%3A+">Request feature</a>
 </p>
 
 ## Table of contents
@@ -22,12 +22,12 @@ This repository contains the OUDS Android library that provides Orange Android c
 
 ## Bugs and feature requests
 
-Have a bug or a feature request? Please first search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/uds-sandbox/uds-android/issues/new/choose).
+Have a bug or a feature request? Please first search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/ouds-sandbox/ouds-android/issues/new/choose).
 
 ## Contributing
 
-Please read through our [contributing guidelines](https://github.com/uds-sandbox/uds-android/blob/main/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
+Please read through our [contributing guidelines](https://github.com/ouds-sandbox/ouds-android/blob/main/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
 
 ## Copyright and license
 
-Code released under the [MIT License](https://github.com/uds-sandbox/uds-android/blob/main/LICENSE).
+Code released under the [MIT License](https://github.com/ouds-sandbox/ouds-android/blob/main/LICENSE).

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
-# UDS Android library changelog
+# OUDS Android library changelog
 
-All notable changes done in UDS Android library will be documented in this file.
+All notable changes done in OUDS Android library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
### Description

This PR applies the naming rules for OUDS Android.

I searched for the following patterns:
* "Orange D"
* "ODS"
* "UDS"
* "uds-"
* "ods-"

Hope that I haven't forgotten anything 😇 
Feel free to override my modifications or close the PR if you want to do it differently :)