### PR TITLE
feat(opacity): update `opacity800` from `0.88f` to `0.80f`

### DIFF
--- a/global-raw-tokens/src/main/java/com/orange/ouds/tokens/global/raw/OpacityRawTokens.kt
+++ b/global-raw-tokens/src/main/java/com/orange/ouds/tokens/global/raw/OpacityRawTokens.kt
@@ -21,6 +21,6 @@ object OpacityRawTokens {
     const val opacity500 = 0.32f
     const val opacity600 = 0.48f
     const val opacity700 = 0.64f
-    const val opacity800 = 0.88f
+    const val opacity800 = 0.80f
     const val opacity900 = 1f
 }


### PR DESCRIPTION
### Description

This PR updates the value of `opacity800` from `0.88f` to `0.80f` following the modification in Figma tokens.

### Types of change

- New feature (non-breaking change which adds functionality)

### Previews

### Checklist

#### Contribution

- [x] I have read
  the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-android/blob/develop/CONTRIBUTING.md)

#### Accessibility

- (N/A) My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows
  the [developer guide](https://github.com/Orange-OpenSource/ouds-android/blob/develop/DEVELOP.md)
- (N/A) I have added unit tests to cover my changes _(optional)_

#### Documentation

- (N/A) My change introduces changes to the documentation and/or I have updated the documentation
  accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [x] Code review
- [x] Design review
- [x] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated
  respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the
  issue